### PR TITLE
Fix vintage mode for d2_coast_11 and 12

### DIFF
--- a/maps/d2_coast_11.edt
+++ b/maps/d2_coast_11.edt
@@ -210,7 +210,30 @@ d2_coast_11
 				//OnTrigger "music_antlionguard_2,PlaySound,,1,-1"
 				OnTrigger "PS_Manager,MovePlayers,,0,-1"
 				OnTrigger "trav_portal_guard,Close,,1,-1"
-				OnTrigger "trav_antireturn_push,Enable,,2,-1"} }
+				OnTrigger "trav_antireturn_push,Enable,,2,-1"
+				OnTrigger "syn_vint_reset,Trigger,,0,1"
+				OnTrigger "syn_restorevint,Trigger,,1,1"} }
+		
+//Restore antlion guards original health for vintage
+		create {classname "logic_relay"
+			values
+			{
+				targetname "syn_restorevint"
+				OnTrigger "npc_antlionguard,SetHealth,500,0,1"
+				OnTrigger "npc_antlionguard,AddOutput,max_health 500,0,1"
+				OnTrigger "skipdoor,kill,,0,-1"
+				OnTrigger "skipdoorprop,kill,,0,-1"
+				OnTrigger "skiptutorial,kill,,0,-1"
+			}
+		}
+		create {classname "logic_relay"
+			values
+			{
+				targetname "syn_vint_reset"
+				OnTrigger "syn_restorevint,kill,,0,-1"
+			}
+		}
+		
 //block
 		create {classname "trigger_push"
 			origin "4480 6816 456"
@@ -508,6 +531,7 @@ d2_coast_11
 		create {classname "prop_dynamic" origin "-405 12075 275"
 			values
 			{
+				targetname "skipdoorprop"
 				model "models/props_lab/freightelevatorbutton.mdl"
 				angles "0 -5 0"
 			}

--- a/maps/d2_coast_12.edt
+++ b/maps/d2_coast_12.edt
@@ -171,16 +171,23 @@ d2_coast_12
 				OnTrigger "syn_vint_trav_tmaker_combine3,Enable,,0,-1"
 				//OnTrigger "syn_vint_trav_combine3_timer,Enable,,0,-1"
 				OnTrigger "assault_template_spawner,ForceSpawn,,0,-1"
+				OnTrigger "syn_vint_additionalfspawn,Trigger,,0,-1"
+				OnTrigger "trav_bigassault_counter,Enable,,5,-1"} }
+		create {classname "logic_relay"
+			values
+			{
+				targetname "syn_vint_additionalfspawn"
 				OnTrigger "assault_template_spawner,ForceSpawn,,2,-1"
 				OnTrigger "assault_template_spawner,ForceSpawn,,4,-1"
-				OnTrigger "trav_bigassault_counter,Enable,,5,-1"} }
+			}
+		}
 //!!
 //Trav|Edt ^ test big assault (needs refining)
 		create {classname "logic_auto"
 			values {spawnflags "1"
 				//OnMapSpawn "assault_soldier_*,AddOutput,OnDeath trav_bigassault_counter:Subtract:1:0:-1,0,-1"
 				//OnMapSpawn "assault_template_spawner,AddOutput,OnEntitySpawned trav_bigassault_counter:Add:4:0:-1,0,-1"
-				OnMapSpawn "assault_template_spawner,AddOutput,OnEntitySpawned trav_bigassault_setuper:Trigger::0:-1,0,-1"} }
+				OnMapSpawn "assault_template_spawner,AddOutput,OnEntitySpawned syn_vint_trav_bigassault_setuper:Trigger::0:-1,0,-1"} }
 //additional waves
 		create {classname"math_counter"
 			values {targetname "trav_bigassault_counter_total"
@@ -196,7 +203,7 @@ d2_coast_12
 				OnHitMin "trav_bigassault_counter_total,Add,1,,-1"} }
 //on squad spawn
 		create {classname "logic_relay"
-			values {targetname "trav_bigassault_setuper"
+			values {targetname "syn_vint_trav_bigassault_setuper"
 				OnTrigger "trav_bigassault_counter,Add,4,0,-1"
 				OnTrigger "assault_soldier_*,AddOutput,OnDeath trav_bigassault_counter:Subtract:1:0:-1,0.1,-1"
 				OnTrigger "assault_soldier_*,AddOutput,targetname syn_assault_soldier,0.2,-1"} }


### PR DESCRIPTION
If on vintage mode (mp_vintage_mode 1), this will affect:
d2_coast_11 - antlionguard original health and removes skip.
d2_coast_12 - reduce combine assault to original size.