### PR TITLE
Increase vehicle spawns for more players

### DIFF
--- a/maps/d1_canals_05.edt
+++ b/maps/d1_canals_05.edt
@@ -40,6 +40,7 @@ d1_canals_05
 				OnTrigger "speaker_arlene_nags,TurnOff,,0,-1"
 
 				OnTrigger "syn_vehiclespawn_1,Enable,,0,-1"
+				OnTrigger "syn_moreplayers,CheckSkill,,1,1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_3,0,-1"
 				OnTrigger "syn_global_settings,AddOutput,IsVehicleMap 1,0,-1"} }
 
@@ -83,6 +84,40 @@ d1_canals_05
 				VehicleSize "164"
 				model "models/airboat.mdl"
 				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "7100 1402 -478.02"
+			values {targetname	"syn_vehiclespawn_1_med"
+				angles "0 90 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+				
+		create {classname "info_vehicle_spawn" origin "6888 1442 -478.02"
+			values {targetname	"syn_vehiclespawn_1_high"
+				angles "0 90 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_vehiclespawn_1_med,Enable,,0,-1"
+				OnHigh "syn_vehiclespawn_1_med,Enable,,0,-1"
+				OnHigh "syn_vehiclespawn_1_high,Enable,,0,-1"
+			}
+		}
 
 //--Checkpoints--
 		create {classname "trigger_once"

--- a/maps/d1_canals_06.edt
+++ b/maps/d1_canals_06.edt
@@ -76,15 +76,78 @@ d1_canals_06
 				StartEnabled "1"
 				RespawnVehicle "1"
 				Ownership "1"
+				VehicleType "2"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "12084 9252 -218.02"
+			values {targetname	"syn_vehiclespawn_1_med"
+				angles "0 90 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
 				Ownership "1"
 				VehicleType "2"
-				//VehicleSize "164"
 				model "models/airboat.mdl"
 				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "12095 8935 -188.02"
+			values {targetname	"syn_vehiclespawn_1_high"
+				angles "0 80 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_vehiclespawn_1_med,Enable,,0,-1"
+				OnHigh "syn_vehiclespawn_1_med,Enable,,0,-1"
+				OnHigh "syn_vehiclespawn_1_high,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayerssec"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_high,Enable,,0,-1"
+			}
+		}
 
 		create {classname "info_vehicle_spawn"
 			origin "-256 6640 -176"
 			values {targetname "syn_spawn_vehicle_2"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-416 6640 -176"
+			values {targetname "syn_spawn_vehicle_2_med"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-75 6640 -176"
+			values {targetname "syn_spawn_vehicle_2_high"
 				StartEnabled "0"
 				RespawnVehicle "1"
 				Ownership "1"
@@ -133,6 +196,7 @@ d1_canals_06
 			values {model "*170"
 				spawnflags "32"
 				OnTrigger "syn_spawn_vehicle_2,Enable,,0,-1"
+				OnTrigger "syn_moreplayerssec,CheckSkill,,0,1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_2,0,-1"} }
 
 //--Exploits--

--- a/maps/d1_canals_07.edt
+++ b/maps/d1_canals_07.edt
@@ -86,12 +86,81 @@ d1_canals_07
 				VehicleType "2"
 				VehicleSize "164"
 				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "7888 7873 -450"
+			values {targetname	"syn_spawn_vehicle_1_med"
+				angles "0 270 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
 				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "7888 8204 -450"
+			values {targetname	"syn_spawn_vehicle_1_high"
+				angles "0 270 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayerssec"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_high,Enable,,0,-1"
+			}
+		}
 
 		create {classname "info_vehicle_spawn" origin "11456 1202 -445"
 			values {targetname	"syn_spawn_vehicle_2"
 				angles "0 90 0"
 				StartEnabled "0"//Enabled in 'Exploits - Failsafe'
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "11456 1050 -445"
+			values {targetname	"syn_spawn_vehicle_2_med"
+				angles "0 90 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "11710 1202 -445"
+			values {targetname	"syn_spawn_vehicle_2_high"
+				angles "0 90 0"
+				StartEnabled "0"
 				RespawnVehicle "1"
 				Ownership "1"
 				VehicleType "2"
@@ -127,6 +196,7 @@ d1_canals_07
 				OnTrigger "base_gate1,EnableMotion,,5,1"
 				OnTrigger "base_gate2,EnableMotion,,5,1"
 				OnTrigger "syn_spawn_vehicle_2,Enable,,0,1"
+				OnTrigger "syn_moreplayerssec,CheckSkill,,0,1"
 				} }
 //Clip -- over gate
 		create {classname "func_vehicleclip" origin "7776 433 -62" values {model "*65"} }

--- a/maps/d1_canals_08.edt
+++ b/maps/d1_canals_08.edt
@@ -134,10 +134,79 @@ d1_canals_08
 				VehicleType "2"
 				VehicleSize "164"
 				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "7592.31 -11485.3 -447.02"
+			values {targetname	"syn_spawn_vehicle_1_med"
+				angles "0 270 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
 				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "7592.31 -11165.3 -447.02"
+			values {targetname	"syn_spawn_vehicle_1_high"
+				angles "0 270 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayerssec"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_high,Enable,,0,-1"
+			}
+		}
 
 		create {classname "info_vehicle_spawn" origin "256 -256 -608"
 			values {targetname	"syn_spawn_vehicle_2"
+				angles "0 180 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "75 -256 -608"
+			values {targetname	"syn_spawn_vehicle_2_med"
+				angles "0 180 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "430 -256 -608"
+			values {targetname	"syn_spawn_vehicle_2_high"
 				angles "0 180 0"
 				StartEnabled "0"
 				RespawnVehicle "1"
@@ -159,6 +228,7 @@ d1_canals_08
 				OnMapSpawn "door_warehouse_basement,AddOutput,OnOpen syn_spawn_manager:SetCheckpoint:syn_spawn_player_2:0:-1,0,-1"
 				OnMapSpawn "door_warehouse_basement,AddOutput,OnOpen syn_neweapon:Enable::0:-1,0,-1"//delay 4.5
 				OnMapSpawn "tower_gate_button,AddOutput,OnClose syn_spawn_vehicle_2:Enable::0:-1,0,-1"
+				OnMapSpawn "tower_gate_button,AddOutput,OnClose syn_moreplayerssec:CheckSkill::0:-1,0,-1"
 				OnMapSpawn "tower_gate_button,AddOutput,OnClose syn_spawn_manager:SetCheckpoint:syn_spawn_player_2:0:-1,0,-1"
 
 				OnMapSpawn "tower_gate_button,AddOutput,OnClose trav_exploit_*:Disable::0:-1,0,-1"} }

--- a/maps/d1_canals_09.edt
+++ b/maps/d1_canals_09.edt
@@ -79,7 +79,7 @@ d1_canals_09
 		create {classname "info_vehicle_spawn" origin "7880 9920 -480.02"
 			values {targetname	"syn_spawn_vehicle_1"
 				angles "0 0 0"
-				StartEnabled "0"
+				StartEnabled "1"
 				RespawnVehicle "1"
 				Ownership "1"
 				VehicleType "2"

--- a/maps/d1_canals_09.edt
+++ b/maps/d1_canals_09.edt
@@ -64,7 +64,7 @@ d1_canals_09
 		create {classname "info_global_settings"
 			values {IsVehicleMap "1" targetname "syn_global_settings"} }
 
-		create {classname "info_vehicle_spawn" origin "7488 9920 -480.02"//7718.65 9928.35 -480.02
+		create {classname "info_vehicle_spawn" origin "7480 9920 -480.02"//7718.65 9928.35 -480.02
 			values {targetname	"syn_spawn_vehicle_1"
 				angles "0 0 0"
 				StartEnabled "1"
@@ -73,21 +73,67 @@ d1_canals_09
 				VehicleType "2"
 				VehicleSize "164"
 				model "models/airboat.mdl"
-				VehicleScript "scripts/vehicles/airboat.txt"} }
+				VehicleScript "scripts/vehicles/airboat.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
 
-		create {classname "info_vehicle_spawn" origin "7872 9920 -480.02"
+		create {classname "info_vehicle_spawn" origin "7880 9920 -480.02"
 			values {targetname	"syn_spawn_vehicle_1"
 				angles "0 0 0"
-				StartEnabled "1"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "7680 9920 -480.02"
+			values {targetname	"syn_spawn_vehicle_1_med"
+				angles "0 0 0"
+				StartEnabled "0"
 				RespawnVehicle "1"
 				Ownership "1"
 				VehicleType "2"
 				VehicleSize "164"
 				model "models/airboat.mdl"
 				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayerssec"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_med,Enable,,0,-1"
+			}
+		}
 
 		create {classname "info_vehicle_spawn" origin "13152 -1632 -480"
 			values {targetname	"syn_spawn_vehicle_2"
+				angles "0 90 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "13152 -1800 -480"
+			values {targetname	"syn_spawn_vehicle_2_med"
 				angles "0 90 0"
 				StartEnabled "0"
 				RespawnVehicle "1"
@@ -109,6 +155,7 @@ d1_canals_09
 			values {model "*19"
 				spawnflags "1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_2,0,-1"
+				OnTrigger "syn_moreplayerssec,CheckSkill,,0,1"
 				OnTrigger "syn_spawn_vehicle_2,Enable,,0,-1"} }
 
 //--Extra--

--- a/maps/d1_canals_10.edt
+++ b/maps/d1_canals_10.edt
@@ -73,10 +73,80 @@ d1_canals_10
 				VehicleType "2"
 				VehicleSize "164"
 				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "11720 -12344 -536"
+			values {targetname	"syn_spawn_vehicle_1_med"
+				angles "0 0 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
 				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "11848 -11895 -525"
+			values {targetname	"syn_spawn_vehicle_1_high"
+				angles "0 0 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayerssec"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_med,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayersthird"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_3_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_3_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_3_high,Enable,,0,-1"
+			}
+		}
 
 		create {classname "info_vehicle_spawn" origin "11592 1136 -432"
 			values {targetname	"syn_spawn_vehicle_2"
+				angles "0 30 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"
+				OnSpawnVehicle "syn_moreplayerssec,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "11400 1136 -432"
+			values {targetname	"syn_spawn_vehicle_2_med"
 				angles "0 30 0"
 				StartEnabled "0"
 				RespawnVehicle "1"
@@ -88,6 +158,29 @@ d1_canals_10
 
 		create {classname "info_vehicle_spawn" origin "5024 9664.01 -448"
 			values {targetname	"syn_spawn_vehicle_3"
+				angles "0 90 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"
+				OnSpawnVehicle "syn_moreplayersthird,CheckSkill,,0,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "5024 9494.01 -448"
+			values {targetname	"syn_spawn_vehicle_3_med"
+				angles "0 90 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "5264 9494.01 -448"
+			values {targetname	"syn_spawn_vehicle_3_high"
 				angles "0 90 0"
 				StartEnabled "0"
 				RespawnVehicle "1"

--- a/maps/d1_canals_11.edt
+++ b/maps/d1_canals_11.edt
@@ -111,11 +111,82 @@ d1_canals_11
 				VehicleType "2"
 				VehicleSize "164"
 				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "9966 9165 -945.70"
+			values {targetname	"syn_spawn_vehicle_1_med"
+				angles "0 165 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
 				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "9900 8672 -940"
+			values {targetname	"syn_spawn_vehicle_1_high"
+				angles "0 180 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayerssec"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_high,Enable,,0,-1"
+			}
+		}
 
 		create {classname "info_vehicle_spawn" origin "6363 4874 -959"//5552 4992.01 -960
 			values {targetname	"syn_spawn_vehicle_2"
 				angles "0 90 0"//105y
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "6588 4832 -959"
+			values {targetname	"syn_spawn_vehicle_2_med"
+				angles "0 90 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "6637 4977 -959"
+			values {targetname	"syn_spawn_vehicle_2_high"
+				angles "0 110 0"
 				StartEnabled "0"
 				StartGunEnabled "1"
 				RespawnVehicle "1"
@@ -145,6 +216,8 @@ d1_canals_11
 				targetname "logic_labVortBeam_Off"
 				OnTrigger "syn_fakeboat,Kill,,0,-1"
 				OnTrigger "syn_spawn_vehicle_2,Enable,,0.01,-1"
+				OnTrigger "prop_vehicle_airboat,EnableGun,1,0.01,-1"
+				OnTrigger "syn_moreplayerssec,CheckSkill,,0.1,-1"
 				OnTrigger "modi_spawn_antiblock2,Enable,,0,-1"} }
 
 		create {classname "prop_dynamic" origin "6363 4874 -964"//-959

--- a/maps/d1_canals_12.edt
+++ b/maps/d1_canals_12.edt
@@ -81,7 +81,68 @@ d1_canals_12
 				VehicleType "2"
 				VehicleSize "164"
 				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,1,1"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "12012 9601.4 551.98"
+			values {targetname	"syn_spawn_vehicle_1_med"
+				angles "0 0 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
 				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "11777 9601.4 551.98"
+			values {targetname	"syn_spawn_vehicle_1_high"
+				angles "0 0 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayerssec"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_med,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayersthird"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_3_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_3_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_3_high,Enable,,0,-1"
+			}
+		}
 
 		create {classname "info_vehicle_spawn" origin "-2784 5200 288"
 			values {targetname	"syn_spawn_vehicle_2"
@@ -94,9 +155,45 @@ d1_canals_12
 				VehicleSize "164"
 				model "models/airboat.mdl"
 				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-3244 5200 288"
+			values {targetname	"syn_spawn_vehicle_2_med"
+				angles "0 180 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
 
 		create {classname "info_vehicle_spawn" origin "-224 -16 160"//-256 240 160 Bunpy 0.o
 			values {targetname	"syn_spawn_vehicle_3"
+				angles "0 180 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-224 186 160"
+			values {targetname	"syn_spawn_vehicle_3_med"
+				angles "0 180 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-224 -216 160"
+			values {targetname	"syn_spawn_vehicle_3_high"
 				angles "0 180 0"
 				StartEnabled "0"
 				StartGunEnabled "1"
@@ -128,12 +225,14 @@ d1_canals_12
 			values {model "*8"
 				spawnflags "1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_2,0,-1"
+				OnTrigger "syn_moreplayerssec,CheckSkill,,0,1"
 				OnTrigger "syn_spawn_vehicle_2,Enable,,0,-1"} }
 
 		create {classname "trigger_once" origin "-960 -256 352"
 			values {model "*34"
 				spawnflags "1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_3,0,-1"
+				OnTrigger "syn_moreplayersthird,CheckSkill,,0,1"
 				OnTrigger "syn_spawn_vehicle_3,Enable,,0,-1"} }
 
 //--Exploits--

--- a/maps/d1_canals_13.edt
+++ b/maps/d1_canals_13.edt
@@ -79,7 +79,45 @@ d1_canals_13
 				VehicleType "2"
 				VehicleSize "164"
 				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,1,1"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "-10850 3110 -421"
+			values {targetname	"syn_spawn_vehicle_1_med"
+				angles "0 180 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
 				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-10650 3110 -421"
+			values {targetname	"syn_spawn_vehicle_1_high"
+				angles "0 180 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				Ownership "1"
+				VehicleType "2"
+				VehicleSize "164"
+				model "models/airboat.mdl"
+				VehicleScript "scripts/vehicles/airboat.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
 
 		create {classname "logic_auto"
 			values {spawnflags "1"

--- a/maps/d2_coast_01.edt
+++ b/maps/d2_coast_01.edt
@@ -59,7 +59,7 @@ d2_coast_01
 				StartEnabled "0"//Enabled after Crane sequence
 				RespawnVehicle "1"
 				StartGunEnabled "1"
-				VehicleType "4"//1&4 disalllows multiple players
+				VehicleType "4"//1&4 disallows multiple players
 				VehicleSize "192"
 				model "models\vehicles\buggy_p2.mdl"//models/buggy.mdl
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
@@ -67,6 +67,40 @@ d2_coast_01
 				//VehicleType "4"
 				//VehicleSize "192"
 				//model "models/vehicles/buggy_p2.mdl"//models/vehicles/buggy_p2.mdl
+		
+		create {classname "info_vehicle_spawn" origin "-7195 -9792 560"
+			values {targetname	"syn_spawn_vehicle_1_med"
+				angles "0 0 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				StartGunEnabled "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-6795 -9792 560"
+			values {targetname	"syn_spawn_vehicle_1_high"
+				angles "0 0 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				StartGunEnabled "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
 
 //--Checkpoints--
 		create {classname "trigger_once"
@@ -142,6 +176,7 @@ d2_coast_01
 		create {classname "logic_relay"
 			values {targetname "logic_jeepflipped"
 				OnTrigger "syn_autosave,Save,,4,-1"
+				OnTrigger "syn_moreplayers,CheckSkill,,3,-1"
 				OnTrigger "syn_spawn_vehicle_1,Enable,,3,-1"} }//trav_2seater_temp,ForceSpawn
 
 //Trav|Edt - delete this tigger (removes stuff)

--- a/maps/d2_coast_03.edt
+++ b/maps/d2_coast_03.edt
@@ -92,12 +92,58 @@ d2_coast_03
 				VehicleType "4"
 				VehicleSize "192"
 				model "models\vehicles\buggy_p2.mdl"//models/buggy.mdl
+				VehicleScript "scripts/vehicles/jeep_test.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "-7340 -12445 1050"
+			values {targetname	"syn_spawn_vehicle_1_med"
+				angles "0 -90 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"//models/buggy.mdl
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-7340 -12645 1050"
+			values {targetname	"syn_spawn_vehicle_1_high"
+				angles "0 -90 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"//models/buggy.mdl
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayersfifth"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_5_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_5_med,Enable,,0,-1"
+			}
+		}
 //First House
 		create {classname "info_vehicle_spawn" origin "-3776 -6400 576"//-4576.01 -4944 240
 			values {targetname	"syn_spawn_vehicle_2"
 				angles "0 90 0"//y0
-				StartEnabled "0"//
+				StartEnabled "0"
 				StartGunEnabled "1"
 				RespawnVehicle "1"
 				VehicleType "4"
@@ -108,7 +154,7 @@ d2_coast_03
 		create {classname "info_vehicle_spawn" origin "-4831.99 4000.01 304"//-5248.01 4751.99 48
 			values {targetname	"syn_spawn_vehicle_3"
 				angles "0 120 0"//y45
-				StartEnabled "0"//
+				StartEnabled "0"
 				StartGunEnabled "1"
 				RespawnVehicle "1"
 				VehicleType "4"
@@ -119,7 +165,7 @@ d2_coast_03
 		create {classname "info_vehicle_spawn" origin "504.01 8407.99 87.99"
 			values {targetname	"syn_spawn_vehicle_4"
 				angles "0 180 0"
-				StartEnabled "0"//
+				StartEnabled "0"
 				StartGunEnabled "1"
 				RespawnVehicle "1"
 				VehicleType "4"
@@ -130,12 +176,23 @@ d2_coast_03
 		create {classname "info_vehicle_spawn" origin "8048 3840 336"
 			values {targetname	"syn_spawn_vehicle_5"
 				angles "0 0 0"
-				StartEnabled "0"//
+				StartEnabled "0"
 				StartGunEnabled "1"
 				RespawnVehicle "1"
 				VehicleType "4"
 				VehicleSize "192"
 				model "models/vehicles/buggy_elite.mdl"//models/vehicles/buggy_p2.mdl
+				VehicleScript "scripts/vehicles/jeep_elite.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "8165 3562 336"
+			values {targetname	"syn_spawn_vehicle_5_med"
+				angles "0 0 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_elite.mdl"
 				VehicleScript "scripts/vehicles/jeep_elite.txt"} }
 //Boathouse Speical
 		create {classname "prop_vehicle_mp"
@@ -376,6 +433,7 @@ d2_coast_03
 //Trav|Edt - enable local vehicle spawn on gunship death
 		create {classname "logic_auto"
 			values {spawnflags "1"
+				OnMapSpawn "aisc_odessapostgunship,AddOutput,OnConditionsSatisfied syn_moreplayersfifth:CheckSkill::5:-1,0,-1"
 				OnMapSpawn "aisc_odessapostgunship,AddOutput,OnConditionsSatisfied syn_spawn_vehicle_5:Enable::5:-1,0,-1"} }
 
 		create {classname "point_teleport"

--- a/maps/d2_coast_04.edt
+++ b/maps/d2_coast_04.edt
@@ -83,17 +83,95 @@ console
 				VehicleType "4"//1&4 disalllows multiple players -v27
 				VehicleSize "192"
 				model "models/vehicles/buggy_p2.mdl"//models/vehicles/buggy_p2.mdl
-				VehicleScript "scripts/vehicles/jeep_test.txt"} }
-//Warehouse
-		create {classname "info_vehicle_spawn" origin "6031.99 -3216.01 392"
-			values {targetname "syn_spawn_vehicle_2"
-				angles "0 180 0"
-				StartEnabled "0"//
+				VehicleScript "scripts/vehicles/jeep_test.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "-9600 -632 112"
+			values {targetname "syn_spawn_vehicle_1_med"
+				angles "0 270 0"
+				StartEnabled "0"
 				StartGunEnabled "1"
 				RespawnVehicle "1"
-				VehicleType "4"//1&4 disalllows multiple players
+				VehicleType "4"
 				VehicleSize "192"
-				model "models\vehicles\buggy_p2.mdl"//models/buggy.mdl
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-9800 -432 112"
+			values {targetname "syn_spawn_vehicle_1_high"
+				angles "0 270 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayerssec"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_med,Enable,,0,-1"
+			}
+		}
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayersthird"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_3_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_3_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_3_high,Enable,,0,-1"
+			}
+		}
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayersfourth"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_4_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_4_med,Enable,,0,-1"
+			}
+		}
+//Warehouse
+		create {classname "info_vehicle_spawn" origin "6140 -3216.01 392"
+			values {targetname "syn_spawn_vehicle_2"
+				angles "0 180 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "5968 -3216.01 392"
+			values {targetname "syn_spawn_vehicle_2_med"
+				angles "0 180 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
 //Prejump
 		create {classname "info_vehicle_spawn" origin "-2080 -2240 1056"
@@ -106,6 +184,28 @@ console
 				VehicleSize "192"
 				model "models\vehicles\buggy_p2.mdl"//models/buggy.mdl
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-2080 -2470 1056"
+			values {targetname "syn_spawn_vehicle_3_med"
+				angles "0 -5 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-2280 -2470 1056"
+			values {targetname "syn_spawn_vehicle_3_high"
+				angles "0 -10 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
 //Post-jump
 		create {classname "info_vehicle_spawn" origin "-1887.99 3016 1000"
 			values {targetname "syn_spawn_vehicle_4"
@@ -116,6 +216,17 @@ console
 				VehicleType "4"//1&4 disalllows multiple players
 				VehicleSize "192"
 				model "models/vehicles/buggy_elite.mdl"//models/vehicles/buggy_p2.mdl
+				VehicleScript "scripts/vehicles/jeep_elite.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-2135 2795 1000"
+			values {targetname "syn_spawn_vehicle_4_med"
+				angles "0 270 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_elite.mdl"
 				VehicleScript "scripts/vehicles/jeep_elite.txt"} }
 
 //--Checkpoints--
@@ -361,6 +472,7 @@ console
 			values {model "*68"
 				spawnflags "32"//vehicle only
 				OnTrigger "syn_spawn_vehicle_2,Enable,,1,-1"
+				OnTrigger "syn_moreplayerssec,CheckSkill,,1,-1"
 				OnTrigger "syn_carreq_push,Disable,,1,-1"
 				OnTrigger "syn_carreq_alert,Disable,,1,-1"
 				OnTrigger "syn_carreq_prop,Kill,,0,1"} }
@@ -380,6 +492,7 @@ console
 			values {spawnflags "1"
 				targetname "jeepwindow_breakrelay"
 				OnTrigger "autosave,save,,3,-1"
+				OnTrigger "syn_moreplayersthird,CheckSkill,,0,-1"
 				OnTrigger "syn_spawn_vehicle_3,Enable,,0,-1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_3b,0,-1"} }
 
@@ -491,6 +604,7 @@ console
 				OnTrigger "autosave,Save,,0,-1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_4,0,-1"
 				OnTrigger "syn_spawn_vehicle_4,Enable,,0,-1"
+				OnTrigger "syn_moreplayersfourth,CheckSkill,,0,-1"
 				//OnTrigger "MPVS_SPAWN,Kill,,1,-1"
 				"OnTrigger" "CP01,SetCheckpoint,,0,1"
 				"OnTrigger" "CP01,MovePlayers,1,0.1,1"

--- a/maps/d2_coast_05.edt
+++ b/maps/d2_coast_05.edt
@@ -79,13 +79,70 @@ d2_coast_05
 		create {classname "info_vehicle_spawn" origin "7600 -12160 1792"
 			values {targetname "syn_spawn_vehicle_1"
 				angles "0 90 0"
-				StartEnabled "1"//
+				StartEnabled "1"
 				StartGunEnabled "1"
 				RespawnVehicle "1"
 				VehicleType "4"//1&4 disalllows multiple players
 				VehicleSize "192"
 				model "models\vehicles\buggy_p2.mdl"//models/buggy.mdl
+				VehicleScript "scripts/vehicles/jeep_test.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "7800 -12160 1792"
+			values {targetname "syn_spawn_vehicle_1_med"
+				angles "0 90 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "8000 -12160 1792"
+			values {targetname "syn_spawn_vehicle_1_high"
+				angles "0 90 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayersthird"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_3_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_3_med,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayersfourth"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_4_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_4_med,Enable,,0,-1"
+			}
+		}
 //First House
 		create {classname "info_vehicle_spawn" origin "-4928 -12224 736"//-6703.96 -12144 711.99
 			values {targetname "syn_spawn_vehicle_2"
@@ -108,8 +165,19 @@ d2_coast_05
 				VehicleSize "192"
 				model "models\vehicles\buggy_p2.mdl"//models/buggy.mdl
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-4720 -4710 1104"
+			values {targetname "syn_spawn_vehicle_3_med"
+				angles "0 15 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
 //Gas Station Workhouse
-		create {classname "info_vehicle_spawn" origin "-5304.01 -40.04 1112"
+		create {classname "info_vehicle_spawn" origin "-5208 -76 1112"
 			values {targetname "syn_spawn_vehicle_4"
 				angles "0 255 0"
 				StartEnabled "0"//
@@ -118,6 +186,17 @@ d2_coast_05
 				VehicleType "4"//1&4 disalllows multiple players
 				VehicleSize "192"
 				model "models\vehicles\buggy_p2.mdl"//models/buggy.mdl
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-5392 -20 1112"
+			values {targetname "syn_spawn_vehicle_4_med"
+				angles "0 255 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
 
 //--Checkpoints--
@@ -137,6 +216,7 @@ d2_coast_05
 				StartDisabled "1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_3,0,-1"
 				OnTrigger "syn_spawn_vehicle_3,Enable,,0,-1"
+				OnTrigger "syn_moreplayersthird,CheckSkill,,0,-1"
 				OnTrigger "syn_checkpoint_3,Enable,,1,-1"
 				OnTrigger "syn_autosave,Save,,1,-1"//only save
 				OnTrigger "syn_newweapon_give,Enable,,30,-1"} }//failsafe
@@ -146,7 +226,7 @@ d2_coast_05
 				OnTrigger "syn_checkpoint_*,Disable,,0,-1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_4,0,-1"
 				OnTrigger "syn_spawn_vehicle_4,Enable,,0,-1"
-} }
+				OnTrigger "syn_moreplayersfourth,CheckSkill,,0,-1"} }
 
 //--Extra--
 	

--- a/maps/d2_coast_07.edt
+++ b/maps/d2_coast_07.edt
@@ -82,7 +82,7 @@ d2_coast_07
 		create {classname "info_global_settings"
 			values {IsVehicleMap "1" targetname "syn_global_settings"} }
 //Intro: Tunnel
-		create {classname "info_vehicle_spawn" origin "-7456 5952 1632"//-3936 6048 1600.95//-6016 6032 1600.95
+		create {classname "info_vehicle_spawn" origin "-7456 5952 1732"//-3936 6048 1600.95//-6016 6032 1600.95
 			values {targetname "syn_spawn_vehicle_1"
 				angles "0 285 0"//y285//y270
 				StartEnabled "1"
@@ -91,7 +91,42 @@ d2_coast_07
 				VehicleType "4"//1&4 disalllows multiple players -v27
 				VehicleSize "192"
 				model "models/vehicles/buggy_p2.mdl"//models/vehicles/buggy_p2.mdl
+				VehicleScript "scripts/vehicles/jeep_test.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "-7846 5792 1732"
+			values {targetname "syn_spawn_vehicle_1_med"
+				angles "0 285 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayersthird"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_3_med,Enable,,0,1"
+				OnHigh "syn_spawn_vehicle_3_med,Enable,,0,1"
+				OnHigh "syn_spawn_vehicle_3_high,Enable,,0,1"
+			}
+		}
 //Small house
 		create {classname "info_vehicle_spawn" origin "-928 8968.01 1680"
 			values {targetname "syn_spawn_vehicle_2"
@@ -108,6 +143,29 @@ d2_coast_07
 			values {targetname "syn_spawn_vehicle_3"
 				angles "0 165 0"
 				StartEnabled "0"//
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"
+				OnSpawnVehicle "syn_moreplayersthird,CheckSkill,,0,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "3825 7325 2064"
+			values {targetname "syn_spawn_vehicle_3_med"
+				angles "0 165 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "3625 7325 2064"
+			values {targetname "syn_spawn_vehicle_3_high"
+				angles "0 165 0"
+				StartEnabled "0"
 				StartGunEnabled "1"
 				RespawnVehicle "1"
 				VehicleType "4"

--- a/maps/d2_coast_09.edt
+++ b/maps/d2_coast_09.edt
@@ -75,7 +75,7 @@ d2_coast_09
 		create {classname "info_global_settings"
 			values {IsVehicleMap "1" targetname "syn_global_settings"} }
 
-		create {classname "info_vehicle_spawn" origin "-14095.3 12064 528"
+		create {classname "info_vehicle_spawn" origin "-14210 12064 630"
 			values {targetname "syn_spawn_vehicle_1"
 				angles "0 180 0"
 				StartEnabled "1"
@@ -84,7 +84,54 @@ d2_coast_09
 				VehicleType "4"//1&4 disalllows multiple players
 				VehicleSize "192"
 				model "models\vehicles\buggy_p2.mdl"//models/buggy.mdl
+				VehicleScript "scripts/vehicles/jeep_test.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,1,1"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "-14210 11864 630"
+			values {targetname "syn_spawn_vehicle_1_med"
+				angles "0 180 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayerssec"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_med,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayersfourth"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_4_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_4_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_4_high,Enable,,0,-1"
+			}
+		}
 
 		create {classname "info_vehicle_spawn" origin "-6768 4192 479.99"
 			values {targetname "syn_spawn_vehicle_2"
@@ -95,6 +142,17 @@ d2_coast_09
 				VehicleType "4"//1&4 disalllows multiple players
 				VehicleSize "192"
 				model "models\vehicles\buggy_p2.mdl"//models/buggy.mdl
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-6768 4192 479.99"
+			values {targetname "syn_spawn_vehicle_2_med"
+				angles "0 210 0"
+				StartEnabled "0"
+				StartGunEnabled "1"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
 
 		create {classname "info_vehicle_spawn" origin "112.01 -7256 -744.01"
@@ -116,6 +174,26 @@ d2_coast_09
 				VehicleType "4"//1&4 disalllows multiple players
 				VehicleSize "192"
 				model "models\vehicles\buggy_p2.mdl"//models/buggy.mdl
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "10224 9900 -176"
+			values {targetname "syn_spawn_vehicle_4_med"
+				angles "0 180 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "10750 9950 -176"
+			values {targetname "syn_spawn_vehicle_4_high"
+				angles "0 150 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models\vehicles\buggy_p2.mdl"
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
 
 //--Checkpoints--
@@ -267,6 +345,7 @@ d2_coast_09
 				spawnflags "1"
 				OnStartTouch "!activator,SetFogController,trav_fog_outside,0,-1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_2,0,1"
+				OnTrigger "syn_moreplayerssec,CheckSkill,,0,1"
 				OnTrigger "syn_spawn_vehicle_2,Enable,,0,1"} }
 				
 			create {classname "trigger_once"
@@ -410,6 +489,7 @@ d2_coast_09
 		create {classname "logic_auto"
 			values {spawnflags "1"
 				OnMapSpawn "gate_door,AddOutput,OnOpen battery_relay_*:Kill::0:-1,0,-1"
+				OnMapSpawn "gate_door,AddOutput,OnOpen syn_moreplayersfourth:CheckSkill::0:-1,0,-1"
 				OnMapSpawn "gate_door,AddOutput,OnOpen syn_spawn_vehicle_4:Enable::0:-1,0,-1"} }
 
 //Trav|Edt - trigger helpers and disable killing combine

--- a/maps/d2_coast_10.edt
+++ b/maps/d2_coast_10.edt
@@ -75,7 +75,7 @@ d2_coast_10
 			create {classname "info_global_settings"
 			values {IsVehicleMap "1" targetname "syn_global_settings"} }
 
-		create {classname "info_vehicle_spawn" origin "-3184.01 -4880 1440"
+		create {classname "info_vehicle_spawn" origin "-3184.01 -4880 1540"
 			values {targetname "syn_spawn_vehicle_1"
 				angles "0 210 0"
 				StartEnabled "1"

--- a/maps/ep2_outland_06a.edt
+++ b/maps/ep2_outland_06a.edt
@@ -54,22 +54,89 @@ ep2_outland_06a
 				RespawnVehicle "1"
 				VehicleType "4"
 				VehicleSize "192"
-				model "models/vehicles/buggy_elite.mdl"//models/vehicles/buggy_p2.mdl
-				VehicleScript "scripts/vehicles/jeep_elite.txt"} }
+				model "models/vehicles/buggy_p2.mdl"//models/vehicles/buggy_elite.mdl
+				VehicleScript "scripts/vehicles/jeep_test.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,1,1"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "4992 456 -2432"
+			values {targetname "syn_spawn_vehicle_1_med"
+				angles "0 90 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "4992 456 -2382"
+			values {targetname "syn_spawn_vehicle_1_high"
+				angles "0 100 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayerssec"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_high,Enable,,0,-1"
+			}
+		}
 
 		create {classname "logic_auto"
 			values {spawnflags "1"
 				OnMapSpawn "al_radio_01,AddOutput,OnTrigger8 syn_spawn_vehicle_2:Enable::0.5:-1,0,-1"
+				OnMapSpawn "al_radio_01,AddOutput,OnTrigger8 syn_moreplayerssec:CheckSkill::0.5:-1,0,-1"
 				OnMapSpawn "al_radio_01,AddOutput,OnTrigger8 modi_antiskip_hurt:Disable::0.5:-1,0,-1"} }
 //postcomtowergate
 		create {classname "info_vehicle_spawn" origin "-4864 -7936 -1504"//-4480 -7552 -1520
 			values {targetname "syn_spawn_vehicle_2"
 				angles "0 90 0"
-				StartEnabled "0"//
+				StartEnabled "0"
 				RespawnVehicle "1"
-				VehicleType "1"
+				VehicleType "4"
 				VehicleSize "192"
-				model "models/buggy.mdl"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-4864 -8136 -1504"
+			values {targetname "syn_spawn_vehicle_2_med"
+				angles "0 85 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-4864 -8336 -1504"
+			values {targetname "syn_spawn_vehicle_2_high"
+				angles "0 70 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
 
 //cruel way of disableing gun

--- a/maps/ep2_outland_07.edt
+++ b/maps/ep2_outland_07.edt
@@ -70,18 +70,72 @@ ep2_outland_07
 				RespawnVehicle "1"
 				VehicleType "4"
 				VehicleSize "192"
-				model "models/vehicles/buggy_elite.mdl"//models/vehicles/buggy_p2.mdl
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,5,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "-1670 -13060 895"
+			values {targetname "syn_spawn_vehicle_1_med"
+				angles "0 90 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_elite.mdl"
 				VehicleScript "scripts/vehicles/jeep_elite.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-2280 -12160 520"
+			values {targetname "syn_spawn_vehicle_1_high"
+				angles "0 90 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayerssec"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_med,Enable,,0,-1"
+			}
+		}
 //Post Advisor Barn
 		create {classname "info_vehicle_spawn" origin "-7295.95 -10752 96"
 			values {targetname "syn_spawn_vehicle_2"
 				angles "0 270 0"
-				StartEnabled "0"//
+				StartEnabled "0"
 				RespawnVehicle "1"
 				VehicleType "4"
 				VehicleSize "192"
 				model "models/vehicle.mdl"//models/vehicles/buggy_p2.mdl
 				VehicleScript "scripts/vehicles/jalopy.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-7685 -10855 120"
+			values {targetname "syn_spawn_vehicle_2_med"
+				angles "0 -90 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
 
 //cruel way of disableing gun
 		create {classname "logic_timer"
@@ -283,9 +337,10 @@ ep2_outland_07
 		
 		create { classname "trigger_once" origin "-7456 -10592 160"
 			values {
-				"model" "*101"
-				"spawnflags" "1"
+				model "*101"
+				spawnflags "1"
 				OnTrigger "syn_spawn_vehicle_2,Enable,,1,-1"
+				OnTrigger "syn_moreplayerssec,CheckSkill,,0,1"
 			}
 		}
 

--- a/maps/ep2_outland_08.edt
+++ b/maps/ep2_outland_08.edt
@@ -62,7 +62,40 @@ ep2_outland_08
 				VehicleType "4"
 				VehicleSize "192"
 				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,1,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "-12262 -10575 448"
+			values {targetname "syn_spawn_vehicle_1_med"
+				angles "0 0 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-12262 -10775 448"
+			values {targetname "syn_spawn_vehicle_1_high"
+				angles "0 0 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
 
 		create {classname "info_vehicle_spawn" origin "-12576 -10240 448"
 			values {targetname	"syn_vint_spawn_vehicle_1"

--- a/maps/ep2_outland_09.edt
+++ b/maps/ep2_outland_09.edt
@@ -71,7 +71,40 @@ ep2_outland_09
 				VehicleType "4"
 				VehicleSize "192"
 				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,1,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "-2136 -8800 128"
+			values {targetname "syn_spawn_vehicle_1_med"
+				angles "0 0 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-1936 -8800 128"
+			values {targetname "syn_spawn_vehicle_1_high"
+				angles "0 0 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
 
 //cruel way of disableing gun
 		create {classname "logic_timer"

--- a/maps/ep2_outland_10.edt
+++ b/maps/ep2_outland_10.edt
@@ -71,12 +71,66 @@ ep2_outland_10
 				VehicleType "4"
 				VehicleSize "192"
 				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,1,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "5092 -9930 -960"
+			values {targetname "syn_spawn_vehicle_1_med"
+				angles "0 345 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "4990 -10185 -960"
+			values {targetname "syn_spawn_vehicle_1_high"
+				angles "0 345 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayerssec"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_med,Enable,,0,-1"
+			}
+		}
 
 		create {classname "info_vehicle_spawn" origin "3488 -64 -128"
 			values {targetname "syn_spawn_vehicle_2"
-				angles "0 345 0"
-				StartEnabled "0"//
+				angles "0 0 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "3668 -64 -128"
+			values {targetname "syn_spawn_vehicle_2_med"
+				angles "0 0 0"
+				StartEnabled "0"
 				RespawnVehicle "1"
 				VehicleType "4"
 				VehicleSize "192"
@@ -85,6 +139,7 @@ ep2_outland_10
 
 		create {classname "logic_relay"
 			values {targetname "logic_ballgenerator1_disabled"
+				OnTrigger "syn_moreplayerssec,CheckSkill,,0,1"
 				OnTrigger "syn_spawn_vehicle_2,Enable,,0,-1"} }
 
 //cruel way of disableing gun

--- a/maps/ep2_outland_10a.edt
+++ b/maps/ep2_outland_10a.edt
@@ -67,12 +67,66 @@ ep2_outland_10a
 				VehicleType "4"
 				VehicleSize "192"
 				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,1,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "4552 -5760 -1536"
+			values {targetname "syn_spawn_vehicle_1_med"
+				angles "0 90 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+			}
+		}
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayerssec"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_2_high,Enable,,0,-1"
+			}
+		}
 //Dog
 		create {classname "info_vehicle_spawn" origin "2824.13 -2786.72 -1800"
 			values {targetname "syn_spawn_vehicle_2"
 				angles "0 345 0"
-				StartEnabled "0"//
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "2624.13 -2786.72 -1800"
+			values {targetname "syn_spawn_vehicle_2_med"
+				angles "0 345 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "2884 -3000 -1800"
+			values {targetname "syn_spawn_vehicle_2_high"
+				angles "0 0 0"
+				StartEnabled "0"
 				RespawnVehicle "1"
 				VehicleType "4"
 				VehicleSize "192"
@@ -82,6 +136,7 @@ ep2_outland_10a
 		create {classname "logic_auto"
 			values {spawnflags "1"
 				OnMapSpawn "alyx_approachdog,AddOutput,OnEndSequence syn_spawn_vehicle_2:Enable::20:-1,0,-1"
+				OnMapSpawn "alyx_approachdog,AddOutput,OnEndSequence syn_moreplayerssec:CheckSkill::20:-1,0,-1"
 				OnMapSpawn "ss_dog_gate,AddOutput,OnScriptEvent01 synvehiclemap:Trigger::0:-1,0,-1"} }
 		create {classname "logic_relay" values {targetname "synvehiclemap" OnTrigger "syn_global_settings,AddOutput,IsVehicleMap 1,0,-1"} }
 // teleport Alyx and car

--- a/maps/ep2_outland_12.edt
+++ b/maps/ep2_outland_12.edt
@@ -56,7 +56,40 @@ ep2_outland_12
 				VehicleType "4"
 				VehicleSize "192"
 				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"
+				OnSpawnVehicle "syn_moreplayers,CheckSkill,,1,-1"} }
+		
+		create {classname "info_vehicle_spawn" origin "-940 -6330 -288"
+			values {targetname "syn_spawn_vehicle_1_med"
+				angles "0 -60 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
 				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "info_vehicle_spawn" origin "-940 -6330 -288"
+			values {targetname "syn_spawn_vehicle_1_high"
+				angles "0 -20 0"
+				StartEnabled "0"
+				RespawnVehicle "1"
+				VehicleType "4"
+				VehicleSize "192"
+				model "models/vehicles/buggy_p2.mdl"
+				VehicleScript "scripts/vehicles/jeep_test.txt"} }
+		
+		create {classname "logic_difficulty"
+			values
+			{
+				targetname "syn_moreplayers"
+				LowerPlayer "10"
+				UpperPlayer "20"
+				OnMed "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_med,Enable,,0,-1"
+				OnHigh "syn_spawn_vehicle_1_high,Enable,,0,-1"
+			}
+		}
 
 	//	create {classname "trigger_once" origin "-704 -7122 -232"
 	//		values {model "*221"


### PR DESCRIPTION
Increased vehicle spawns for larger player counts using logic_difficulty.
Current trigger player counts are 15 for medium counts and enable 1 extra, then 20+ for enabling an additional spawn after that.