### PR TITLE
Patch 21 Change d2_prison static precache models

### DIFF
--- a/maps/d2_prison_01.edt
+++ b/maps/d2_prison_01.edt
@@ -75,7 +75,10 @@ d2_prison_01
 //Trav|Edt - freeze ragdolls in water when near
 		create {classname "trigger_once"
 			origin "2024 -3680 1152"
-			values {model "*31"
+			values {
+				//model "*31"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "2024 -3680 1152"
 				spawnflags "1"
 				OnTrigger "corpse,DisableMotion,,0,-1"} }
 
@@ -140,7 +143,10 @@ d2_prison_01
 
 		create {classname "trigger_coop"
 			origin "920 -1452 1664"
-			values {model "*60"
+			values {
+				//model "*60"
+				edt_mins "-400 -150 -100"
+				edt_maxs "410 240 100"
 				spawnflags "1"
 				targetname "syn_antirush_trigger2"
 				CountType "1"
@@ -169,7 +175,10 @@ d2_prison_01
 
 		create {classname "trigger_once"
 			origin "1064 -1536 1664"
-			values {model "*17"
+			values {
+				//model "*17"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "1064 -1536 1664"
 				spawnflags "1"
 				StartDisabled "1"
 				targetname "syn_endmoveplayers"

--- a/maps/d2_prison_02.edt
+++ b/maps/d2_prison_02.edt
@@ -47,7 +47,10 @@ d2_prison_02
 
 		create {classname "trigger_multiple"
 			origin "-1080 3388 440"
-			values {model "*32"
+			values {
+				//model "*32"
+				edt_getbspmodelfor_classname "trigger_multiple"
+				edt_getbspmodelfor_origin "-1080 3388 440"
 				spawnflags "1"
 				targetname "syn_new_weapon_trigger"
 				//StartDisabled "1"
@@ -192,7 +195,10 @@ d2_prison_02
 
 		create {classname "trigger_once"
 			origin "-1592 2576 430"
-			values {model "*13"
+			values {
+				//model "*13"
+				edt_getbspmodelfor_classname "trigger_look"
+				edt_getbspmodelfor_origin "-1388 2940 434"
 				spawnflags "1"
 				OnTrigger "monitor_1,Enable,,0,-1"
 				OnTrigger "shower_soldier_spawner,ForceSpawn,,0,-1"
@@ -201,7 +207,10 @@ d2_prison_02
 //Trav|Edt - autirush
 		create {classname "trigger_coop"
 			origin "-2490.15 1175.31 700"
-			values {model "*6"
+			values {
+				//model "*6"
+				edt_getbspmodelfor_classname "trigger_multiple"
+				edt_getbspmodelfor_origin "-1898.15 2595.31 316"
 				spawnflags "1"
 				//StartDisabled "1"
 				targetname "syn_antirush_coop"

--- a/maps/d2_prison_03.edt
+++ b/maps/d2_prison_03.edt
@@ -94,7 +94,10 @@ d2_prison_03
 
 		create {classname "trigger_once"
 			origin "-3120 1632 62"
-			values {model "*30"
+			values {
+				//model "*30"
+				edt_getbspmodelfor_classname "trigger_multiple"
+				edt_getbspmodelfor_origin "-3120 1632 62"
 				spawnflags "1"
 				OnTrigger "trav_guard_spawner,ForceSpawn,,0,-1"
 				OnTrigger "syn_spawn_manager,MovePlayers,,0,-1"} }
@@ -142,7 +145,10 @@ d2_prison_03
 
 		create {classname "trigger_once"
 			origin "-3384 3504 64"
-			values {model "*52"//*53
+			values {
+				//model "*52"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "-3384 3520 64"
 				spawnflags "1"
 				OnTrigger "trav_tmaker_combine1,Enable,,0,-1"} }
 
@@ -203,7 +209,10 @@ d2_prison_03
 
 		create {classname "trigger_once"
 			origin "-3728 4912 196"
-			values {model "*37"//*38
+			values {
+				//model "*37"//*38
+				edt_getbspmodelfor_classname "trigger_multiple"
+				edt_getbspmodelfor_origin "-3728 4912 196"
 				spawnflags "1"
 				OnTrigger "monitor_1,Enable,,0.25,-1"} }
 
@@ -212,7 +221,10 @@ d2_prison_03
 
 		create {classname "trigger_multiple"
 			origin "-3414 5824 72"
-			values {model "*86"
+			values {
+				//model "*86"
+				edt_getbspmodelfor_classname "trigger_multiple"
+				edt_getbspmodelfor_origin "-3414 5824 72"
 				spawnflags "1"
 				OnEndTouchAll "fan_motor,TurnOff,,0.5,-1"
 				OnEndTouchAll "fan_wind,Disable,,0,-1"
@@ -222,7 +234,10 @@ d2_prison_03
 //Trav|Edt - stop fan movement when broken and clear
 		create {classname "trigger_once"
 			origin "-3469 5822 26.5"
-			values {model "*84"
+			values {
+				//model "*84"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "-3615 5827 21.5"
 				spawnflags "1"
 				targetname "trav_fan_disablemotion"
 				StartDisabled "1"
@@ -235,7 +250,10 @@ d2_prison_03
 
 		create {classname "trigger_once"
 			origin "-3469 5822 26.5"
-			values {model "*84"
+			values {
+				//model "*84"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "-3615 5827 21.5"
 				spawnflags "1"
 				OnTrigger "trav_tmaker_combine3,Enable,,0,-1"} }
 				

--- a/maps/d2_prison_04.edt
+++ b/maps/d2_prison_04.edt
@@ -92,7 +92,10 @@ d2_prison_04
 
 		create {classname "trigger_once"
 			origin "-672 2096 304"
-			values {model "*42"
+			values {
+				//model "*42"
+				edt_getbspmodelfor_classname "trigger_multiple"
+				edt_getbspmodelfor_origin "-672 2096 304"
 				spawnflags "1"
 				OnTrigger "trav_tmaker_combine1,Enable,,0,-1"} }
 
@@ -125,7 +128,10 @@ d2_prison_04
 //Trav|Edt - autirush
 		create {classname "trigger_coop"
 			origin "-1336 2880 418"
-			values {model "*44"
+			values {
+				//model "*44"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "-1216 1736 434"
 				spawnflags "1"
 				targetname "syn_antirush_coop"
 				CountType "1"

--- a/maps/d2_prison_05.edt
+++ b/maps/d2_prison_05.edt
@@ -122,7 +122,10 @@ d2_prison_05
 
 		create {classname "trigger_once"
 			origin "-256 1758.25 464"
-			values {model "*38"
+			values {
+				//model "*38"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "-256 1758.25 464"
 				spawnflags "1"
 				OnTrigger "trav_tmaker_combine1,Enable,,0,-1"} }
 
@@ -131,7 +134,10 @@ d2_prison_05
 
 		create {classname "trigger_once"
 			origin "1304 1156 448"
-			values {model "*37"
+			values {
+				//model "*37"
+				edt_getbspmodelfor_classname "trigger_multiple"
+				edt_getbspmodelfor_origin "1304 1156 448"
 				spawnflags "1"
 				OnTrigger "monitor_1,Enable,,0,-1"
 				OnTrigger "monitor_1,SetCamera,laundry_camera,0,-1"} }
@@ -157,7 +163,10 @@ d2_prison_05
 //checkpoint
 		create {classname "trigger_once"
 			origin "-2204 512 704.2"
-			values {model "*69"
+			values {
+				//model "*69"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "-2204 512 704.22"
 				spawnflags "1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_2,0,-1"
 				OnTrigger "syn_spawn_manager,MovePlayers,,0,-1"} }
@@ -180,7 +189,10 @@ d2_prison_05
 
 		create {classname "trigger_once"
 			origin "-4048 -528 560"
-			values {model "*85"
+			values {
+				//model "*85"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "-4048 -528 560"
 				spawnflags "1"
 				OnTrigger "syn_spawn_manager,MovePlayers,,0,-1"} }
 
@@ -197,7 +209,10 @@ d2_prison_05
 
 		create {classname "trigger_once"
 			origin "-4048 -528 560"
-			values {model "*80"
+			values {
+				//model "*80"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "-3536 -544 560"
 				spawnflags "1"
 				//OnTrigger "point_of_no_return,Enable,,0,-1"
 				OnTrigger "combine_crusherwall1_ss,BeginSequence,,0,-1"
@@ -213,7 +228,9 @@ d2_prison_05
 //still can go through prop, but no biggie, for now.
 		create {classname "func_brush"
 			origin "-4376 -280 1145.79"
-			values {model "*104"
+			values {
+				//model "*104"
+				edt_getbspmodelfor_targetname "hurt_trigger_crusher_2"
 				spawnflags "2"
 				StartDisabled "1"
 				rendermode "10"
@@ -221,7 +238,9 @@ d2_prison_05
 
 		create {classname "func_brush"
 			origin "-4224 -360 1145.79"
-			values {model "*104"
+			values {
+				//model "*104"
+				edt_getbspmodelfor_targetname "hurt_trigger_crusher_2"
 				spawnflags "2"
 				StartDisabled "1"
 				rendermode "10"
@@ -230,7 +249,10 @@ d2_prison_05
 //Trav|Edt - autirush
 		create {classname "trigger_coop"
 			origin "-4476.04 -997.64 704"
-			values {model "*75"
+			values {
+				//model "*75"
+				edt_getbspmodelfor_classname "trigger_look"
+				edt_getbspmodelfor_origin "-1644.04 -973.64 576"
 				spawnflags "1"
 				StartDisabled "1"//enabled by combine_crusherwall2_ss
 				targetname "syn_antirush_coop"

--- a/maps/d2_prison_06.edt
+++ b/maps/d2_prison_06.edt
@@ -146,8 +146,8 @@ d2_prison_06
 		//edit {classname "prop_door_rotating" values {returndelay "-1"} }
 
 //Trav|Edt - block phys props going into vator
-		create {classname "func_clip_vphysics" origin "1440 664 -560" values {model "*143"} }
-		create {classname "func_clip_vphysics" origin "1440 688 -560" values {model "*143"} }
+		create {classname "func_clip_vphysics" origin "1440 664 -560" values {edt_getbspmodelfor_classname "trigger_multiple" edt_getbspmodelfor_origin "-116 1016 144"} }//model "*143"
+		create {classname "func_clip_vphysics" origin "1440 688 -560" values {edt_getbspmodelfor_classname "trigger_multiple" edt_getbspmodelfor_origin "-116 1016 144"} }
 
 //Trav|Edt - Disable Enemy turrets when tipped (avoid player greif)
 		create {classname "logic_auto"
@@ -172,7 +172,9 @@ d2_prison_06
 		delete {targetname "int_door_close_inside_1"}
 		create {classname "trigger_coop"
 			origin "544 8 48"
-			values {model "*101"
+			values {
+				//model "*101"
+				edt_getbspmodelfor_targetname "int_door_close_inside_1"
 				spawnflags "1"
 				StartDisabled "1"
 				targetname "int_door_close_inside_1"
@@ -186,7 +188,10 @@ d2_prison_06
 				
 		create {classname "trigger_once"
 			origin "312 -256 8"
-			values {model "*119"
+			values {
+				//model "*119"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "1180 -1590 -116"
 				spawnflags "1"
 				OnTrigger "syn_spawn_manager,TeleportPlayers,syn_spawn_player_4_teleport,0.1,-1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_4,0,-1"} }
@@ -200,9 +205,12 @@ d2_prison_06
 //Trav|Edt - impulse to block peeps from putting props in vent to block players
 		create {classname "func_clip_vphysics"
 			origin "910 -1144 20"
-			values {model "*70"
-			targetname "trav_vphysclip_vent"
-			filtername "trav_vphysclip_vent_filter"} }
+			values {
+				//model "*70"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "1038 -1144 20"
+				targetname "trav_vphysclip_vent"
+				filtername "trav_vphysclip_vent_filter"} }
 
 		create {classname "filter_multi"
 			values {targetname "trav_vphysclip_vent_filter"
@@ -235,7 +243,10 @@ d2_prison_06
 
 		create {classname "trigger_once"
 			origin "1180 -1778 -116"
-			values {model "*119"
+			values {
+				//model "*119"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "1180 -1590 -116"
 				spawnflags "1"
 				OnTrigger "trav_maker_headcrabs1,Enable,,0,-1"
 				//OnTrigger "syn_spawn_manager,MovePlayers,,0,-1"
@@ -256,7 +267,10 @@ d2_prison_06
 //Trav|Edt - moveplayers on dropdown in vent
 		create {classname "trigger_once"
 			origin "1180 -1338 -52"
-			values {model "*119"
+			values {
+				//model "*119"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "1180 -1590 -116"
 				spawnflags "1"
 				OnTrigger "syn_spawn_manager,TeleportPlayers,syn_spawn_player_3_teleport,0.1,-1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_3,0,-1"} }
@@ -423,7 +437,8 @@ d2_prison_06
 
 			"values"
 			{
-				"model" "*101"
+				//"model" "*101"
+				"edt_getbspmodelfor_targetname" "int_door_close_inside_1"
 				"targetname" "int_door_close_inside_1"
 				"spawnflags" "1"
 				"StartDisabled" "1"
@@ -455,8 +470,9 @@ d2_prison_06
 			"origin" "960 416 -128"
 			"values"
 			{
-				"model" "*96"
-				"spawnflags" "1"
+				//"model" "*96"
+				edt_getbspmodelfor_targetname "Trigger_security_scene"
+				spawnflags "1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_6,0,-1"
 				OnTrigger "syn_spawn_manager,MovePlayers,syn_spawn_player_6,0.1,-1"
 			}

--- a/maps/d2_prison_07.edt
+++ b/maps/d2_prison_07.edt
@@ -93,7 +93,10 @@ d2_prison_07
 //Trav|Edt - Close gate if all in (and move checkpoint)
 		create {classname "trigger_coop"
 			origin "-44.5 -3672 -91.5"
-			values {model "*23"
+			values
+			{
+				//model "*23"
+				edt_getbspmodelfor_targetname "trigger_ensure_no_combine_left"
 				spawnflags "1"
 				CountType "1"
 				UseHUD "0"
@@ -569,9 +572,13 @@ d2_prison_07
 
 //Trav|Edt - autirush
 		create {classname "trigger_coop"
-			origin "4041 -4312 -676"
-			values {model "*95"
-				angles "0 90 0"
+			origin "4155 -4345 -655"
+			values
+			{
+				//angles "0 90 0"
+				//model "*95"
+				edt_mins "-750 -300 -100"
+				edt_maxs "500 100 80"
 				spawnflags "1"
 				targetname "syn_antirush_coop"
 				CountType "1"

--- a/maps/d2_prison_08.edt
+++ b/maps/d2_prison_08.edt
@@ -15,7 +15,7 @@ d2_prison_08
 		edit {classname "func_areaportal" values {targetname "disabledPortal" StartOpen "1"} }
 
 //Prevent Backtracking
-		create {classname "trigger_push" origin "64 0 0"
+		create {classname "trigger_push" origin "-2780 3025 1000"
 			values {
 				//model "*90"
 				edt_mins "-20 -100 -80"

--- a/maps/d2_prison_08.edt
+++ b/maps/d2_prison_08.edt
@@ -16,7 +16,10 @@ d2_prison_08
 
 //Prevent Backtracking
 		create {classname "trigger_push" origin "64 0 0"
-			values {model "*90"
+			values {
+				//model "*90"
+				edt_mins "-20 -100 -80"
+				edt_maxs "20 100 80"
 				spawnflags "1"
 				speed "750"
 				pushdir "0 0 0"} }
@@ -131,7 +134,10 @@ d2_prison_08
 
 		create {classname "trigger_once"
 			origin "-2416 3040 1015.5"
-			values {model "*92"
+			values {
+				//model "*92"
+				edt_getbspmodelfor_classname "trigger_once"
+				edt_getbspmodelfor_origin "-2416 3040 1015.5"
 				spawnflags "1"
 				OnTrigger "alyx,StopScripting,,0,-1"
 				OnTrigger "unholster,Start,,0,-1"} }
@@ -163,7 +169,9 @@ d2_prison_08
 
 		create {classname "trigger_teleport"
 			origin "-1120 1232 1028"
-			values {model "*30"
+			values {
+				//model "*30"
+				edt_getbspmodelfor_targetname "trigger_tp_scene_start"
 				spawnflags "8"
 				targetname "trav_turrets_teleport"
 				StartDisabled "1"
@@ -191,7 +199,9 @@ d2_prison_08
 
 		create {classname "trigger_once"
 			origin "96 240 996"
-			values {model "*30"
+			values {
+				//model "*30"
+				edt_getbspmodelfor_targetname "trigger_tp_scene_start"
 				spawnflags "1"
 				OnTrigger "syn_spawn_manager,SetCheckpoint,syn_spawn_player_3,0,-1"} }
 				
@@ -240,7 +250,9 @@ d2_prison_08
 //Trav|Edt - Close mossman's door when all players are in
 		create {classname "trigger_coop"
 			origin "-464 480 992"
-			values{model "*31"
+			values{
+				//model "*31"
+				edt_getbspmodelfor_targetname "trigger_close_console_door_1"
 				spawnflags "1"
 				targetname "trav_coop_moss"
 				CountType "1"
@@ -252,7 +264,9 @@ d2_prison_08
 //Trav|Edt - Close teleporter room door when all players are in
 		create {classname "trigger_coop"
 			origin "96 240 996"
-			values{model "*30"
+			values{
+				//model "*30"
+				edt_getbspmodelfor_targetname "trigger_tp_scene_start"
 				spawnflags "1"
 				targetname "trav_coop_teleporterroom"
 				StartDisabled "1"
@@ -267,7 +281,9 @@ d2_prison_08
 		//alyx in teleporter room before coop trig enable
 		create {classname "trigger_once"
 			origin "96 240 996"
-			values {model "*30"
+			values {
+				//model "*30"
+				edt_getbspmodelfor_targetname "trigger_tp_scene_start"
 				spawnflags "2"
 				filtername "trav_filter_alyx"
 				OnTrigger "trav_coop_teleporterroom,Enable,,0,-1"} }
@@ -401,7 +417,9 @@ d2_prison_08
 
 		create {classname "trigger_once"
 			origin "128 -10 1093.84"
-			values {model "*35"
+			values {
+				//model "*35"
+				edt_getbspmodelfor_targetname "trigger_teleport_player_enter_1"
 				spawnflags "1"
 				StartDisabled "1"
 				targetname "trigger_teleport_player_enter_1"
@@ -462,7 +480,8 @@ d2_prison_08
 			"origin" "-752 949.8 1024"
 			"values"
 			{
-				"model" "*29"
+				//"model" "*29"
+				"edt_getbspmodelfor_targetname" "trigger_teleport01"
 				"targetname" "trigger_teleport01"
 				"spawnflags" "1"
 				"StartDisabled" "1"
@@ -500,7 +519,8 @@ d2_prison_08
 			"origin" "-464 480 992"
 			"values"
 			{
-				"model" "*31"
+				//"model" "*31"
+				"edt_getbspmodelfor_targetname" "trigger_close_console_door_1"
 				"targetname" "trigger_close_console_door_1"
 				"spawnflags" "1"
 				"StartDisabled" "1"
@@ -521,7 +541,8 @@ d2_prison_08
 			"origin" "96 240 996"
 			"values"
 			{
-				"model" "*30"
+				//"model" "*30"
+				"edt_getbspmodelfor_targetname" "trigger_tp_scene_start"
 				"targetname" "trigger_tp_scene_start"
 				"spawnflags" "1"
 				"StartDisabled" "0"


### PR DESCRIPTION
Change all d2_prison_* maps to use edt_getbspmodelfor_* and some edt_mins and edt_maxs instead of static precached models.