### PR TITLE
Patch 32

### DIFF
--- a/maps/ep2_outland_02.edt
+++ b/maps/ep2_outland_02.edt
@@ -4,6 +4,7 @@ ep2_outland_02
 	{
 		//sk_antlionguard_health 7100 //500
 		mp_player_death_items 0
+		sv_test_scripted_sequences "1"
 	}
 	entity
 	{
@@ -46,7 +47,9 @@ ep2_outland_02
 				OnMapSpawn "relay_gman_scene_end,AddOutput,OnTrigger zoomtodefault:Zoom::0:-1,0,-1"
 				OnMapSpawn "pathTrack_elevator_alyx_stop,AddOutput,OnPass vort_healsAlyx:CancelSequence::1:1,0,-1"
 				OnMapSpawn "pathTrack_elevator_alyx_stop,AddOutput,OnPass vort_healsAlyx:kill::1.1:1,0,-1"
-				OnMapSpawn "lcs_gman_scene,AddOutput,OnTrigger14 syn_g1:Teleport::3.3:-1,0,-1"} }
+				//OnMapSpawn "lcs_gman_scene,AddOutput,OnTrigger14 syn_g1:Teleport::3.3:-1,0,-1"
+			}
+		}
 
 // env_zooms - all players
 		create {classname "logic_auto"
@@ -539,7 +542,7 @@ ep2_outland_02
 
 		// -----------------
 		//create { classname "info_player_coop" origin "-3089 -9460 -3110" values { angles "0 -90 0" targetname "PS_TransEle" StartDisabled "1" } }
-		create {classname "point_teleport" origin "-856 -12781 -1096" values {targetname "syn_g1" target "gman" angles "0 180 0"} }
+		//create {classname "point_teleport" origin "-856 -12781 -1096" values {targetname "syn_g1" target "gman" angles "0 180 0"} }
 
 		create { classname "info_teleport_destination" origin "-3120 -9309 -899" values { angles "0 -50 0" targetname "syn_spawn_player_3_TP" } }
 

--- a/maps/ep2_outland_06a.edt
+++ b/maps/ep2_outland_06a.edt
@@ -1,5 +1,9 @@
 ep2_outland_06a
 {
+	console
+	{
+		sv_test_scripted_sequences "1"
+	}
 	entity
 	{
 //--Setup--


### PR DESCRIPTION
Ep2_outland_02
- Fix GMan leaning over sequence breaking.
Ep2_outland_06a
- Fix Alyx hiding sequence going through the wall.

The issue is actually in the SDK Base 2013 Multiplayer code which is easily fixed by removing one #ifdef HL2MP or using sv_test_scripted_sequences 1 There is slightly more overhead with sv_test_scripted_sequences 1 instead of the simple fix in the code, but this will still work.